### PR TITLE
Fix room disposal when client disconnects

### DIFF
--- a/src/main/kotlin/game/WordWarGame.kt
+++ b/src/main/kotlin/game/WordWarGame.kt
@@ -153,6 +153,23 @@ object WordWarGame {
         }
     }
 
+    suspend fun disconnectPlayer(roomId: String, playerId: String) {
+        mutex.withLock {
+            val room = rooms[roomId] ?: return
+            room.players.remove(playerId)
+            room.state.update { gameState ->
+                gameState.copy(
+                    connectedPlayers = room.players.map { PlayerState(it.value.name, it.value.id) }
+                )
+            }
+
+            if (room.players.isEmpty()) {
+                broadcastToRoom(roomId, "Room $roomId will be disposed.")
+                rooms.remove(roomId)
+            }
+        }
+    }
+
     /*
         PRIVATE FUNCTIONS
     */

--- a/src/main/kotlin/server/Sockets.kt
+++ b/src/main/kotlin/server/Sockets.kt
@@ -42,8 +42,8 @@ fun Application.configureSockets() {
                 println("Error: ${e.message}")
                 this.send("Some error occurred while connecting to the server")
             } finally {
-                WordWarGame.disposeRoom(roomId)
-                close(CloseReason(CloseReason.Codes.NORMAL, "Room $roomId disposed"))
+                WordWarGame.disconnectPlayer(roomId, playerId)
+                close(CloseReason(CloseReason.Codes.NORMAL, "Connection closed"))
             }
         }
     }


### PR DESCRIPTION
## Summary
- keep rooms alive when a client disconnects
- remove players individually and only dispose when empty

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684a2cc840a083238119bd76293cfdbf